### PR TITLE
Update README to correct parameters of the meta transition function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export default {
         userId: 123
       }
       meta: {
-        transition: (state, action) => ({
+        transition: (prevState, nextState, action) => ({
           pathname: `/logged-in/${action.payload.userId}`,
           search: '?a=query',
           state: {
@@ -82,7 +82,7 @@ export default {
         userId: 123
       }
       meta: {
-        transition: (state, action) => (
+        transition: (prevState, nextState, action) => (
           Promise.delay(3000).then(() => {
             pathname: `/logged-in/${action.payload.userId}`,
             search: '?a=query',


### PR DESCRIPTION
This tripped me up a few times, so I decided to send in a PR to clear it up. The README still has the parameters of the meta transition function as (state, action), but the current version of this package and the example use (prevState, nextState, action).
