### PR TITLE
Include meta.done property in transition.success example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ export default {
         username: 'testuser'
       },
       meta: {
+        done: true,
         transition: {
           success: (prevState, nextState, action) => ({
             pathname: `/user/${action.payload.userId}`,


### PR DESCRIPTION
Thanks for this great library!  I think it will be very useful on my project.

I really like the options for `transition.success` and `transition.failure`.  But it took me a while to implement in my project because the example in `README.md` doesn't specify the `meta.done: true` option.  Even though the reliance on `meta.done` is mentioned in the paragraph above, it didn't click for me until I started picking through the source code to debug.

This pull request will amend the `transition.success` example to specify that property.
